### PR TITLE
Abrir documentacion plugin

### DIFF
--- a/godot/addons/abrir_documentacion/abrir_documentacion.gd
+++ b/godot/addons/abrir_documentacion/abrir_documentacion.gd
@@ -1,0 +1,13 @@
+@tool
+extends EditorPlugin
+
+const AbrirDocumentacionInspectorPlugin = preload("res://addons/abrir_documentacion/abrir_documentacion_inspector_plugin.gd")
+var inspector_plugin
+
+func _enter_tree():
+	inspector_plugin = AbrirDocumentacionInspectorPlugin.new()
+	add_inspector_plugin(inspector_plugin)
+
+
+func _exit_tree():
+	remove_inspector_plugin(inspector_plugin)

--- a/godot/addons/abrir_documentacion/abrir_documentacion_inspector_plugin.gd
+++ b/godot/addons/abrir_documentacion/abrir_documentacion_inspector_plugin.gd
@@ -1,0 +1,18 @@
+extends EditorInspectorPlugin
+
+func _can_handle(object: Object) -> bool:
+	var object_script = object.get_script()
+	return object_script and\
+		object_script is GDScript\
+		and object_script.get_global_name()
+
+func _parse_begin(object: Object):
+	var open_docs_button := Button.new()
+	open_docs_button.text = "Abrir documentacion"
+	open_docs_button.pressed.connect(func():
+		var object_class_name: String = object.get_script().get_global_name()
+		var help_topic: String = str("class_name:", object_class_name)
+
+		EditorInterface.get_script_editor().goto_help(help_topic)
+	)
+	add_custom_control(open_docs_button)

--- a/godot/addons/abrir_documentacion/plugin.cfg
+++ b/godot/addons/abrir_documentacion/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="abrir_documentacion"
+description=""
+author="JuanFdS"
+version=""
+script="abrir_documentacion.gd"

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -29,6 +29,9 @@ window/size/viewport_width=1280
 window/size/viewport_height=720
 window/stretch/mode="canvas_items"
 window/stretch/aspect="keep_height"
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/abrir_documentacion/plugin.cfg")
 
 [gui]
 


### PR DESCRIPTION
Agrega un plugin al proyecto con el cual se puede abrir la documentación de nodos cuyos scripts tengan un `class_name`.


https://github.com/user-attachments/assets/86ab3c8e-dd5a-476e-ab7c-bbf18ff6e127

